### PR TITLE
Correction: Battery Share does not work on Pixel 10 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Legend:
 |Magic Cue|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|
 |Live Notifications|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|✅|
 |Face Unlock|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|❌|
-|Battery Share|❌|✅|✅|❌|✅|✅|❌|✅|✅|❌|✅|✅|❌|✅|✅|
+|Battery Share|❌|❌|❌|❌|✅|✅|❌|✅|✅|❌|✅|✅|❌|✅|✅|
 
 ### Launcher/Lockscreen
 | Feature | 10a | 10P | 10 | 9a | 9P | 9 | 8a | 8P | 8 | 7a | 7P | 7 | 6a | 6P | 6 |


### PR DESCRIPTION
I marked Battery Share as available on the Pixel 10 series because it was available on previous generations, but it turns out Google removed Battery Share from the Pixel 10 series altogether. I corrected my mistake, sorry!

- ❌ Confirmed that Battery Share does not work on the Pixel 10 series