### PR TITLE
Added "Rules" feature and an alternative for "Now Playing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Legend:
 | Circle to Search                                        | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Extreme Battery Saver                                   | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Flip to Shhh [(Alternative)](#open-source-alternatives) | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
-| Now Playing                                             | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
+| Now Playing [(Alternative)](#open-source-alternatives)  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Quick Tap [(Alternative)](#open-source-alternatives)    | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Plug into external display                              | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Magic Cue                                               | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Live Notifications                                      | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Face Unlock                                             | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Battery Share                                           | ❌  | ❌  | ❌  | ❌  | ✅  | ✅  | ❌  | ✅  | ✅  | ❌  | ✅  | ✅  | ❌  | ✅  | ✅  |
+| Rules                                                   | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 
 ### Android Auto
 
@@ -139,7 +140,7 @@ Legend:
 | Photo Unblur          | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  |
 | Pro mode              | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  |
 | Manual lens selection | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  | ❌  | ✅  | ❌  |
-| Pro Res Zoom          | ❌  | ✅  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
+| Pro Res Zoom <sup>`🛜1️⃣`</sup>         | ❌  | ✅  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 | Camera Coach <sup>`🛜`</sup>        | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 
 ### Google Recorder
@@ -197,4 +198,5 @@ Note that these apps are not endorsed by myself or the GrapheneOS team.
 | Feature | Alternative |
 | ------------ | ---------------------------------------------------- |
 | Flip to Shhh | [Flip 2 DND](https://github.com/robinsrk/flip_2_dnd) |
+| Now Playing | [Ambient Music Mod](https://github.com/KieronQuinn/AmbientMusicMod)
 | Quick Tap | [TapTap](https://github.com/KieronQuinn/TapTap) |


### PR DESCRIPTION
- Added the "Rules" feature
- Added an alternative for "Now Playing"
- Marked "Pro Res Zoom" as "Requires network access only for initial setup"


Unrelated to this PR, but the readme says 

> "If you discover a feature which is listed as supported but does not work without Sandboxed Google Play Services, feel free to submit an issue so we can update the documentation."

but currently none of the features that require Google Play Services are marked as such (for example "Find my Device"). Are you aware of this?